### PR TITLE
req now consumes all the parts of the (multi-part) message in order to preserve the req/rep flow.

### DIFF
--- a/src/Network/Zmcat.hs
+++ b/src/Network/Zmcat.hs
@@ -4,6 +4,7 @@ module Network.Zmcat where
 import System.ZMQ3
 import Control.Monad (forever)
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as C
 import Data.ByteString.Char8 (pack, unpack)
 import System.IO
 
@@ -59,6 +60,6 @@ req uri = runCtx Req $ \skt -> do
     forever $ do
         pkt <- hGetLine stdin
         send skt [] (pack pkt)
-        line <- receive skt
-        putStrLn $ unpack line
+        lines' <- receiveMulti skt
+        mapM_ C.putStrLn lines'
         hFlush stdout


### PR DESCRIPTION
Hi Lucas

I was using this program in a project of mine and I noticed that the req/rep pattern broke on multi-part messages, i.e. when the counterparty sends a multi-part rep.

I fixed the issue for my needs and decided to send you a pull request for the changes. Feel free to include the changes upstream :)

Best regards
Gisli
