### PR TITLE
Allow GHC 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 dist
+.cabal-sandbox
+cabal.sandbox.config
+dist-newstyle

--- a/src/Network/Zmcat.hs
+++ b/src/Network/Zmcat.hs
@@ -1,7 +1,7 @@
 
 module Network.Zmcat where
 
-import System.ZMQ3
+import System.ZMQ4
 import Control.Monad (forever)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as C

--- a/zmcat.cabal
+++ b/zmcat.cabal
@@ -37,7 +37,7 @@ library
   exposed-modules:  Network.Zmcat
   build-depends:    bytestring,
                     base >= 4.5.1.0 && < 5,
-                    zeromq3-haskell >= 0.3.1
+                    zeromq4-haskell >= 0.6.4
 
 executable zmcat
     main-is: bin/Zmcat.hs


### PR DESCRIPTION
Hi Lucas, 

I was recently involved into discussion about your utility `zmcat` and realised that folks who don't use Haskell on regular basis struggled a lot with installation of it right now.

Based on #3, I shift dependency boundaries that will allow to build it even on GHC 8.

Thanks,
Andrey